### PR TITLE
fix: disable SBOM upload-release-assets

### DIFF
--- a/.github/workflows/build_and_push_docker_image_to_ghcr.yaml
+++ b/.github/workflows/build_and_push_docker_image_to_ghcr.yaml
@@ -154,6 +154,7 @@ jobs:
           image: ${{ inputs.image_name }}@${{ steps.build-and-push.outputs.digest }}
           format: spdx-json
           output-file: sbom.spdx.json
+          upload-release-assets: false
 
       - name: Cosign attest SBOM
         if: ${{ inputs.cosign_attest_sbom }}


### PR DESCRIPTION
`anchore/sbom-action` defaults `upload-release-assets: true`, which causes it to attach SBOMs from any component build to whatever the latest GitHub release is. In a monorepo setup this means url-read/url-gen/frontend SBOMs get incorrectly attached to api-gateway releases.

Setting `upload-release-assets: false` keeps the SBOM generated and uploaded as a workflow artifact + cosign-attested, without the spurious release attachment.