### PR TITLE
feat(ci): add trivy_scan input and remove metadata-action auto-tags

### DIFF
--- a/.github/workflows/build_and_push_docker_image_to_ghcr.yaml
+++ b/.github/workflows/build_and_push_docker_image_to_ghcr.yaml
@@ -44,6 +44,10 @@ on:
         required: false
         type: boolean
         default: true
+      trivy_scan:
+        required: false
+        type: boolean
+        default: true
     outputs:
       image_digest:
         description: Image digest
@@ -105,6 +109,7 @@ jobs:
           echo "image_with_digest=${{ inputs.image_name }}@${{ steps.build-and-push.outputs.digest }}" >> "$GITHUB_OUTPUT"
 
       - name: Trivy scan
+        if: ${{ inputs.trivy_scan }}
         uses: aquasecurity/trivy-action@0.24.0
         with:
           image-ref: ${{ inputs.image_name }}@${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/build_and_push_docker_image_to_ghcr.yaml
+++ b/.github/workflows/build_and_push_docker_image_to_ghcr.yaml
@@ -91,7 +91,6 @@ jobs:
           tags: |
             ${{ inputs.image_name }}:${{ inputs.image_tag }}
             ${{ inputs.push_latest && format('{0}:latest', inputs.image_name) || '' }}
-            ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           # Disable built-in provenance and SBOM generation; we use anchore/sbom-action
           # and Cosign-based SBOM attestation instead (see steps below).


### PR DESCRIPTION
## Summary
- Add `trivy_scan` boolean input (default: `true`) — callers can set `trivy_scan: false` to skip Trivy when needed
- Remove `${{ steps.meta.outputs.tags }}` from the build-push `tags:` list — `docker/metadata-action` was auto-generating `pr-NNN` / branch tags that caused a duplicate manifest push alongside the caller-provided `image_tag`; the `labels` output is still used for OCI metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)