### PR TITLE
refactor(ci): rename scan_severity/ignore_unfixed to trivy_ prefix

### DIFF
--- a/.github/workflows/build_and_push_docker_image_to_ghcr.yaml
+++ b/.github/workflows/build_and_push_docker_image_to_ghcr.yaml
@@ -28,11 +28,11 @@ on:
         required: false
         type: boolean
         default: false
-      scan_severity:
+      trivy_scan_severity:
         required: false
         type: string
         default: CRITICAL,HIGH
-      ignore_unfixed:
+      trivy_ignore_unfixed:
         required: false
         type: boolean
         default: true
@@ -115,8 +115,8 @@ jobs:
           image-ref: ${{ inputs.image_name }}@${{ steps.build-and-push.outputs.digest }}
           format: table
           exit-code: "1"
-          severity: ${{ inputs.scan_severity }}
-          ignore-unfixed: ${{ inputs.ignore_unfixed }}
+          severity: ${{ inputs.trivy_scan_severity }}
+          ignore-unfixed: ${{ inputs.trivy_ignore_unfixed }}
 
       - name: Publish build provenance attestation
         uses: actions/attest-build-provenance@v1


### PR DESCRIPTION
## Summary
- Rename `scan_severity` → `trivy_scan_severity`
- Rename `ignore_unfixed` → `trivy_ignore_unfixed`

Prefixing with `trivy_` makes all Trivy-related inputs consistent alongside the existing `trivy_scan` input added in #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)