### PR TITLE
chore: bump actions/attest-build-provenance from v1 to v4

### DIFF
--- a/.github/workflows/build_and_push_docker_image_to_ghcr.yaml
+++ b/.github/workflows/build_and_push_docker_image_to_ghcr.yaml
@@ -119,7 +119,7 @@ jobs:
           ignore-unfixed: ${{ inputs.trivy_ignore_unfixed }}
 
       - name: Publish build provenance attestation
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v4
         with:
           subject-name: ${{ inputs.image_name }}
           subject-digest: ${{ steps.build-and-push.outputs.digest }}


### PR DESCRIPTION
## Summary
- Bumps `actions/attest-build-provenance` from `v1` to `v4` (latest: `v4.1.0`)

## Why
`v4` is the latest stable release. As of `v4`, the action is a wrapper on top of `actions/attest`, keeping the same interface while benefiting from upstream improvements in attestation handling.

## Test plan
- [ ] Trigger a workflow run and verify the attestation step completes successfully
- [ ] Check the attestation is visible on the package page in GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)